### PR TITLE
Created third type of menu: stdout-json

### DIFF
--- a/src/com/yifanlu/Kindle/JSONMenu.java
+++ b/src/com/yifanlu/Kindle/JSONMenu.java
@@ -38,7 +38,7 @@ import java.util.Iterator;
 public class JSONMenu implements Menuable {
     private static final LogMessage JSON_MENU_ITEM = new LogMessage("JsonMenuItem", new String[]{"name", "action", "params"});
     private File mJsonFile;
-    private LauncherAction[] mMenuItems;
+    protected LauncherAction[] mMenuItems;
     private boolean mDynamic;
 
     /**
@@ -132,6 +132,17 @@ public class JSONMenu implements Menuable {
         FileReader read = new FileReader(mJsonFile);
         JSONParser parse = new JSONParser();
         JSONObject obj = (JSONObject) parse.parse(read);
+        updateActions(obj);
+    }
+
+    /** 
+     * Takes loaded JSONObject, converts it to LauncherAction and 
+     * adds its menu items if it is a submenu or adds itself
+     *
+     * @throws IOException    if there is a problem reading the JSON text
+     * @throws ParseException if there is a problem parsing the JSON text
+     */
+    protected void updateActions(JSONObject obj) throws IOException, ParseException {
         LauncherAction action = jsonToAction(obj, null);
         if (action instanceof LauncherMenu && action.getValue().equals("No Text")) {
             mMenuItems = ((LauncherMenu) action).getMenuItems();

--- a/src/com/yifanlu/Kindle/StdoutJSONMenu.java
+++ b/src/com/yifanlu/Kindle/StdoutJSONMenu.java
@@ -1,0 +1,122 @@
+/**
+ * Kindle Launcher
+ * GUI menu launcher for Kindle Touch
+ * Copyright (C) 2011  Yifan Lu
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.yifanlu.Kindle;
+
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+import org.json.simple.parser.ParseException;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * This class holds the menu options for a stdout JSON menu.
+ *
+ * @author Vasilij Litvinov
+ * @version 1.0
+ */
+public class StdoutJSONMenu extends JSONMenu {
+    private File mScript;
+    private String mArgs;
+    private int mTimeout;
+    private File mExtDir;
+
+    /**
+     * Create a new StdoutJSONMenu object with the command and arguments to invoke that prints JSON-formatted menu to stdout
+     * for JSONMenu format see JSONMenu class
+     *
+     * @param script   The shell script or command to run
+     * @param extDir   Directory where extention that is being loaded lives, ignored if script starts with "/"
+     * @param args     The arguments of the script
+     * @param timeout  timeout to wait before terminating; don't terminate if 0
+     */
+    public StdoutJSONMenu(String script, File extDir, String args, int timeout) {
+        super(new File(extDir, "dummy.json"));
+        // passing dummy.json to JSONMenu constructor as jsonFile - we won't be reading a file anyway
+        // but it would be needed when JSONMenu.jsonToAction kicks into action
+        if (script.startsWith("/"))
+            mScript = new File(script);
+        else
+            mScript = new File(extDir, script);
+        mArgs = args;
+        mTimeout = timeout;
+        mExtDir = extDir;
+        setDynamic(false); // tell our ancestor not to reload anything
+    }
+    
+    public String getScriptStr() {
+        String result = mScript.getAbsolutePath();
+        if (mArgs != "")
+            result = result + " " + mArgs;
+        return result;
+    }
+
+    /**
+     * Here we call the command and parse its output
+     *
+     * @param menu The menu of the caller.
+     */
+    public void addItemsToMenu(LauncherMenu menu) {
+        KindleLauncher.LOG.debug("Refreshing the menu");
+        try {
+            parseJSONMenu();
+        } catch (IOException e) {
+            KindleLauncher.LOG.error("Cannot create menu because script <" + getScriptStr() + "> cannot be executed?");
+            e.printStackTrace();
+        } catch (ParseException e) {
+            KindleLauncher.LOG.error("Cannot create menu because script <" + getScriptStr() + "> output cannot be parsed.");
+            e.printStackTrace();
+        }
+        super.addItemsToMenu(menu);
+    }
+
+
+    /**
+     * Executes the command stored in the object and parses its stdout as JSON
+     * stops executing if command returned non-zero exit code or non-empty stderr
+     *
+     * @throws IOException    if there is a problem reading the JSON text
+     * @throws ParseException if there is a problem parsing the JSON text
+     */
+    public void parseJSONMenu() throws IOException, ParseException {
+        mMenuItems = new LauncherMenu[]{};
+        JSONParser parse = new JSONParser();
+        
+        StringBuffer out = new StringBuffer();
+        StringBuffer err = new StringBuffer();
+        String cmd = "/mnt/us/extensions/wdexec.sh " + mExtDir.getAbsolutePath() + " ";
+        if (mTimeout > 0) {
+            cmd += "../timeout.sh -t " + mTimeout + " ";
+        }
+        cmd += getScriptStr();
+        int retcode = KindleLauncher.SERVICES.getDeviceService().exec(cmd, out, err);
+        if (retcode != 0) {
+            throw new IOException("Script <" + cmd + "> returned non-zero exit code: " + retcode);
+        }
+        if (err.length() != 0) {
+            throw new IOException("Script <" + cmd + "> returned non-emtpy stderr: " + err.toString());
+        }
+        
+        KindleLauncher.LOG.debug("Loading JSON from script <" + cmd + "> stdout: " + out.toString());
+        JSONObject obj = (JSONObject) parse.parse(out.toString());
+        
+        updateActions(obj);
+    }
+
+}

--- a/src/scripts/timeout.sh
+++ b/src/scripts/timeout.sh
@@ -1,0 +1,88 @@
+#!/bin/sh
+
+##########################################################################
+# Shellscript:	timeout - set timeout for a command
+# Author     :	Heiner Steven <heiner.steven@odn.de>
+# Date       :	29.07.1999
+# Category   :	File Utilities
+# Requires   :
+# SCCS-Id.   :	@(#) timeout	1.3 03/03/18
+##########################################################################
+# Description
+#    o	Runs a command, and terminates it (by sending a signal) after
+#	a specified time period
+#    o	This command first starts itself as a "watchdog" process in the
+#	background, and then runs the specified command.
+#	If the command did not terminate after the specified
+#	number of seconds, the "watchdog" process will terminate
+#	the command by sending a signal.
+#
+# Notes
+#    o	Uses the internal command line argument "-p" to specify the
+#	PID of the process to terminate after the timeout to the
+#	"watchdog" process.
+#    o	The "watchdog" process is invoked by the name "$0", so
+#	"$0" must be a valid path to the script.
+#    o	If this script runs in the environment of the login shell
+#	(i.e. it was invoked using ". timeout command...") it will
+#	terminate the login session.
+##########################################################################
+ 
+PN=`basename "$0"`			# Program name
+VER='1.3'
+ 
+TIMEOUT=5				# Default [seconds]
+ 
+Usage () {
+    echo >&2 "$PN - set timeout for a command, $VER
+usage: $PN [-t timeout] command [argument ...]
+     -t: timeout (in seconds, default is $TIMEOUT)"
+    exit 1
+}
+ 
+Msg () {
+    for MsgLine
+    do echo "$PN: $MsgLine" >&2
+    done
+}
+ 
+Fatal () { Msg "$@"; exit 1; }
+
+Timeout=${TIMEOUT}			# Set default [seconds]
+ 
+while [ $# -gt 0 ]
+do
+    case "$1" in
+	-p)	ParentPID=$2; shift;;	# Used internally!
+	-t)	Timeout="$2"; shift;;
+	--)	shift; break;;
+	-h)	Usage;;
+	-*)	Usage;;
+	*)	break;;			# First file name
+    esac
+    shift
+done
+  
+if [ -z "$ParentPID" ]
+then
+    # This is the first invokation of this script.
+    # Start "watchdog" process, and then run the command.
+    [ $# -lt 1 ] && Fatal "please specify a command to execute"
+    "$0" -p $$ -t $Timeout &		# Start watchdog
+    #echo >&2 "DEBUG: process id is $$"
+    exec "$@"				# Run command
+    exit 2				# NOT REACHED
+else
+    # We run in "watchdog" mode, $ParentPID contains the PID
+    # of the process we should terminate after $Timeout seconds.
+    [ $# -ne 0 ] && Fatal "please do not use -p option interactively"
+ 
+    #echo >&2 "DEBUG: $$: parent PID to terminate is $ParentPID"
+ 
+    exec >/dev/null 0<&1 2>&1	# Suppress error messages
+    sleep $Timeout
+    kill $ParentPID &&			# Give process time to terminate
+    	(sleep 2; kill -1 $ParentPID) &&
+	(sleep 2; kill -9 $ParentPID)
+    exit 0
+fi

--- a/src/scripts/wdexec.sh
+++ b/src/scripts/wdexec.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+cd "$1"
+shift
+
+exec "$@"


### PR DESCRIPTION
It enables developer create extensions that make menus right when user taps "Launcher" thus making it possible to create stuff like "status" menus that would show e.g. correct state of USB networking regardless of device reboots/USB networking changes and such

Would be great if you have a look at this and maybe incorporate into your launcher.
